### PR TITLE
feat: add deadly cross bonus

### DIFF
--- a/css/bonus.css
+++ b/css/bonus.css
@@ -1,4 +1,5 @@
 /* Bonus: Multi-bomb Powerup */
+
 .bonus {
   width: 20px;
   height: 20px;
@@ -14,7 +15,9 @@
   100% { transform: translateY(0px); }
 }
 
+
 /* Bonus: Invicibility */
+
 .bonus.invincibility {
   background: #ff66ff; /* Rose vif */
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
@@ -25,4 +28,36 @@
   0% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.1); opacity: 0.8; }
   100% { transform: scale(1); opacity: 1; }
+}
+
+/* Bonus: deadly-bonus-cross */
+
+.bonus.deadly {
+  background: transparent;
+  width: 20px;
+  height: 20px;
+  position: absolute;
+}
+
+.bonus.deadly::before,
+.bonus.deadly::after {
+  content: "";
+  position: absolute;
+  background: black;
+}
+
+.bonus.deadly::before {
+  left: 9px;
+  top: 2px;
+  width: 2px;
+  height: 16px;
+  border-radius: 1px;
+}
+
+.bonus.deadly::after {
+  top: 9px;
+  left: 2px;
+  width: 16px;
+  height: 2px;
+  border-radius: 1px;
 }

--- a/js/bombs.js
+++ b/js/bombs.js
@@ -1,6 +1,6 @@
 import { playground } from './dom.js';
 import { step } from './constants.js';
-import { state } from './state.js'; // Import correct
+import { state } from './state.js';
 import { isObstacleAt } from './obstacles.js';
 import { checkPlayerHit } from './players.js';
 import { getMaxX, getMaxY } from './utils.js';
@@ -80,12 +80,20 @@ export function explodeBomb(bombElement) {
           state.obstacleGrid[gridY][gridX] = null;
 
           // 10% chance de générer un bonus (ajouté ici)
-          if (Math.random() < 0.1) {
+          if (Math.random() < 1/7) {
             const bonus = document.createElement('div');
             bonus.className = 'bonus';
 
-            // Choix aléatoire du type de bonus (50% multi-bomb, 50% invincibility)
-            const bonusType = Math.random() > 0.5 ? 'multi-bomb' : 'invincibility';
+            // 1/3 chance deadly, sinon réparti entre multi-bomb et invincibility
+            const rand = Math.random();
+            let bonusType;
+            if (rand < 1/3) {
+              bonusType = 'deadly';
+            } else if (rand < 2/3) {
+              bonusType = 'multi-bomb';
+            } else {
+              bonusType = 'invincibility';
+            }
             bonus.classList.add(bonusType);
             bonus.dataset.type = bonusType;
 
@@ -94,6 +102,7 @@ export function explodeBomb(bombElement) {
             playground.appendChild(bonus);
             state.bonuses.push({ element: bonus, x: cell.x, y: cell.y });
           }
+
         }
       }
     }

--- a/js/bonus.js
+++ b/js/bonus.js
@@ -1,5 +1,8 @@
 import { state } from './state.js';
 import { playerRed, playerBlue } from './dom.js';
+import { updateLives, updatePlayerColors } from './players.js';
+import { endGame } from './game.js';
+import { getMaxX, getMaxY } from './utils.js';
 
 export function checkBonusCollision(player) {
   const playerKey = player.toLowerCase();
@@ -9,6 +12,38 @@ export function checkBonusCollision(player) {
   for (let i = state.bonuses.length - 1; i >= 0; i--) {
     const bonus = state.bonuses[i];
     if (bonus.x === playerX && bonus.y === playerY) {
+      if (bonus.element.dataset.type === 'deadly') {
+        // Le joueur perd une vie immédiatement
+        if (player === 'Red') {
+          state.livesRed--;
+          updateLives();
+          updatePlayerColors();
+          playerRed.style.backgroundColor = 'black';
+          setTimeout(() => {
+            playerRed.style.backgroundColor = '';
+            state.posRed.x = 0;
+            state.posRed.y = 0;
+            playerRed.style.left = '0px';
+            playerRed.style.top = '0px';
+            updatePlayerColors();
+          }, 100);
+          if (state.livesRed <= 0) endGame('Red');
+        } else if (player === 'Blue') {
+          state.livesBlue--;
+          updateLives();
+          updatePlayerColors();
+          playerBlue.style.backgroundColor = 'black';
+          setTimeout(() => {
+            playerBlue.style.backgroundColor = '';
+            state.posBlue.x = getMaxX();
+            state.posBlue.y = getMaxY();
+            playerBlue.style.left = `${state.posBlue.x}px`;
+            playerBlue.style.top = `${state.posBlue.y}px`;
+            updatePlayerColors();
+          }, 100);
+          if (state.livesBlue <= 0) endGame('Blue');
+        }
+      }
       if (bonus.element.dataset.type === 'multi-bomb') {
         state.playerStats[playerKey].maxBombs = 3;
         state.playerStats[playerKey].bonusBombsLeft = 3;


### PR DESCRIPTION
- Added black cross bonus that causes instant life loss when collected
- Bonus appears randomly alongside other power-ups
- Updated bonus collision logic and visuals